### PR TITLE
null model values not reflecting in model changes

### DIFF
--- a/jquery.binddata.js
+++ b/jquery.binddata.js
@@ -28,7 +28,7 @@
         for (var prop in bean) {
             var propname = (propPrefix) ? propPrefix + '.' + prop : prop;
             var type = typeof(bean[prop]);
-            if ('object' === type) {
+            if ('object' === type && bean[prop] !== null) {
             	if(bean[prop] instanceof Date) {
             		ret[propname] = convertDateToStringIfNeeded(getPropValue(bean, prop));
             	}


### PR DESCRIPTION
Null model values not reflecting on model changes. Due to the fact that typeof(null) returns 'object', each property with a null value disappears from the model. This fix ensures that `getPropValue()` will be called in such cases.
